### PR TITLE
👷 Replace Repology with Alpine CDN datasource for package pins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -25,14 +31,23 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{{replace 'openssh-client-default' 'openssh' package}}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{{replace 'openssh-client-default' 'openssh' package}}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": ["alpine_3_24/npm"],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Renovate's `repology` datasource has stopped resolving Alpine package pins across the hassio-addons org. Every `alpine_3_24/*` lookup returns `no-result`, so the Alpine pins in `node-red/Dockerfile` are no longer updated at all, and builds break whenever upstream moves a pinned package. Repology rate limits its `tools/project-by` endpoint hard, and each run resolves every pin through it.

This applies the same fix already landed on app-ssh (hassio-addons/app-ssh#1119) to this repository:

- Add a `custom.alpine` datasource that reads the Alpine CDN directory listing (`https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/`) using Renovate's `html` format.
- Point the Alpine custom manager at `custom.alpine` and add `extractVersionTemplate` to pull the version out of each `.apk` filename. The leading `\d` in that regex is what stops, for example, `nano` from matching `nano-syntax-...`.
- Swap the `repology` package rule over to `custom.alpine`.
- Add a rule pointing `npm` at the Alpine community repository. Custom datasources use `registryStrategy: "first"`, so multiple `registryUrls` are not hunted and community packages would otherwise fail to resolve.

`depNameTemplate` is unchanged, so the existing `openssh-client-default` to `openssh` mapping is preserved; the extract regex uses the raw package name, which is what the CDN filenames use.

### Verification

A passing CI build proves nothing here, since the config change does not touch the Dockerfile and the `apk` layer is served from cache. Verified locally instead:

- `renovate-config-validator .github/renovate.json` passes.
- A local dry-run (`RENOVATE_PLATFORM=local RENOVATE_DRY_RUN=lookup`) resolves **11 of 11** pins, matching the 11 pinned packages in `node-red/Dockerfile`. Every dependency comes back with a `currentVersion` and an empty `warnings` array.
- `grep -c "Found no results"` on the debug log is **0**.
- Repository membership was derived mechanically from the v3.24 `APKINDEX` files rather than copied from app-ssh: `npm` is the only community package; the other ten (`build-base`, `git`, `icu-data-full`, `linux-headers`, `nginx`, `nodejs`, `openssh-client-default`, `patch`, `py3-pip`, `python3-dev`) live in main. `npm` resolves against the community registry URL in the dry-run output, as expected. No pin exists outside both indexes.
- The dry-run reports **no updates**, which matches the APKINDEX cross-check: all 11 pins are already at the latest version for v3.24. So no stale pin is currently blocking anything in this repository.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Applies the same change as hassio-addons/app-ssh#1119.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated handling of Alpine Linux package updates.
  - Enabled more reliable version detection and update routing for Alpine packages.
  - Streamlined automatic integration of compatible Alpine updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->